### PR TITLE
Add required new line to shebangLine

### DIFF
--- a/src/main/antlr4/KotlinParser.g4
+++ b/src/main/antlr4/KotlinParser.g4
@@ -862,7 +862,7 @@ identifier
     ;
 
 shebangLine
-    : ShebangLine
+    : ShebangLine NL+
     ;
 
 quest


### PR DESCRIPTION
The grammar allows the following code:
```
 #! package my_package
```
But it's not a valid code for the Kotlin parser.
After shebangLine must be at least one newline.